### PR TITLE
tests, docstring comments, improved help, and light refactoring for `keeper edit` subcommand

### DIFF
--- a/keeper/main.py
+++ b/keeper/main.py
@@ -83,11 +83,16 @@ def random_tasks(args):
 
 
 def find_first_editor():
-    editors_to_try = ['xed', 'gedit', 'vim', 'nano', 'emacs']
-    for editor in editors_to_try:
+    """
+    :raises: RuntimeError
+    :rtype: str
+    :return: first installed editor from the `settings.POSSIBLE_EDITORS` list
+    """
+    for editor in settings.POSSIBLE_EDITORS:
         if 0 == subprocess.call(['which', editor]):
             return editor
-    raise Exception('No editor found. Please configure one in .keeperrc')
+    raise RuntimeError('No editor found. Please configure one in .keeperrc')
+
 
 
 def edit(args):
@@ -98,7 +103,7 @@ def edit(args):
     else:
         editor = settings.EDITOR
     os.system(editor + " " +
-              " ".join([tasks.get_dir()+fn for fn in full_filenames]))
+              " ".join([os.path.join(settings.APP_DIRECTORY, fn) for fn in full_filenames]))
 
 
 def show_topics(args):
@@ -111,17 +116,17 @@ def show_topics(args):
 
 
 def done(args):
-    lists_dir = tasks.get_dir()
+    lists_dir = settings.APP_DIRECTORY
     for filename in args.files:
-        _from, _to = lists_dir+filename+".todo", lists_dir+filename+".done"
+        _from, _to = os.path.join(lists_dir, filename + ".done"), os.path.join(lists_dir, filename + ".todo")
         print("moving {} to {}".format(_from, _to))
         os.rename(_from, _to)
 
 
 def undo(args):
-    lists_dir = tasks.get_dir()
+    lists_dir = settings.APP_DIRECTORY
     for filename in args.files:
-        _from, _to = lists_dir+filename+".done", lists_dir+filename+".todo"
+        _from, _to = os.path.join(lists_dir, filename + ".done"), os.path.join(lists_dir, filename + ".todo")
         print("moving {} to {}".format(_from, _to))
         os.rename(_from, _to)
 

--- a/keeper/main.py
+++ b/keeper/main.py
@@ -15,10 +15,7 @@ DURATION_GETTER = operator.attrgetter('duration_left')
 
 
 def get_taskpool():
-    lists_dir = tasks.get_dir()
-    tasks.mkdir_p(lists_dir)
-    taskpool = tasks.load_all()
-    return taskpool
+    return tasks.load_all()
 
 
 def check(args):
@@ -135,6 +132,9 @@ def main():
     """
     Entrypoint
     """
+    # check and create app directory if necessary
+    tasks.mkdir_p(settings.APP_DIRECTORY)
+
     parser = argparse.ArgumentParser(description='console timekeeper')
     subparsers = parser.add_subparsers()
     parser_check = subparsers.add_parser('check',

--- a/keeper/settings.py
+++ b/keeper/settings.py
@@ -2,7 +2,11 @@
 import os
 
 
-EDITOR = 'auto'
+EDITOR = 'auto'  # set your preferred editor here or 'auto' to look for editors from `POSSIBLE_EDITORS` list
+
+# editors to try if `EDITOR = auto`
+POSSIBLE_EDITORS = ['xed', 'gedit', 'vim', 'nano', 'emacs']
+
 
 IGNORED_SECTIONS = {'done', 'debts', 'delegated', 'wontdo', 'library',
                     'scratch', 'optional', 'paid', 'ext', 'external',
@@ -13,12 +17,13 @@ SYNONYMS = {'ext': 'external'}
 HARD_PAGE_TIME = 0.2
 EASY_PAGE_TIME = 0.1
 
-# on first import try to find .keeperrc in home dir. If it is there, execute it
+# application directory (e.g. `~/.keeper` expanded to full `/home/<user>/.keeper` on Linux)
+APP_DIRECTORY = os.path.expanduser('~/.keeper')
 
+# on first import try to find .keeperrc in home dir. If it is there, execute it
 rc_file = os.path.expanduser('~/.keeperrc')
 
-try:
+# update locals() from .keeperrc file
+if os.path.exists(rc_file):
     with open(rc_file) as f:
         exec(f.read())
-except FileNotFoundError:
-   pass

--- a/keeper/tasks.py
+++ b/keeper/tasks.py
@@ -6,7 +6,7 @@ import os.path
 import errno
 import timespans
 
-from keeper.settings import HARD_PAGE_TIME, EASY_PAGE_TIME, IGNORED_SECTIONS
+from keeper.settings import HARD_PAGE_TIME, EASY_PAGE_TIME, IGNORED_SECTIONS, APP_DIRECTORY
 
 strptime = datetime.datetime.strptime
 ONE_DAY = datetime.timedelta(days=1)
@@ -28,10 +28,6 @@ def set_line(filename, lineno, line):
     data[lineno] = line + '\n'
     with open(filename, 'w') as file:
         file.writelines(data)
-
-
-def get_dir():
-    return os.path.expanduser('~/.keeper')+'/'
 
 
 def get_duration(s):
@@ -557,8 +553,8 @@ class TaskList:
 
 def load_all():
     task_pool = TaskList()
-    lists_dir = get_dir()
+    lists_dir = APP_DIRECTORY
     for filename in os.listdir(lists_dir):
         if filename.endswith('.todo'):
-            task_pool.load_from_file(lists_dir+filename)
+            task_pool.load_from_file(os.path.join(lists_dir, filename))
     return task_pool

--- a/keeper/tasks.py
+++ b/keeper/tasks.py
@@ -13,13 +13,13 @@ ONE_DAY = datetime.timedelta(days=1)
 
 
 def mkdir_p(path):
-    try:
-        os.makedirs(path)
-    except OSError as exc:  # Python >2.5
-        if exc.errno == errno.EEXIST and os.path.isdir(path):
-            pass
-        else:
-            raise
+    """
+    create directory {path} if necessary
+    """
+    if os.path.exists(path) and os.path.isdir(path):
+        return
+
+    os.makedirs(path)
 
 
 def set_line(filename, lineno, line):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 timespans
-
+pytest

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,11 @@
 import os
 import sys
 
+
 try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
-
 
 
 if sys.argv[-1] == 'publish':
@@ -18,7 +18,6 @@ if sys.argv[-1] == 'publish':
 
 with open(os.path.join(os.path.dirname(__file__), 'README.md')) as f:
     readme = f.read()
-
 
 
 classifiers = [
@@ -31,6 +30,7 @@ classifiers = [
         'Programming Language :: Python :: 3.5',
         'Topic :: Office/Business :: Scheduling',
 ]
+
 
 setup(
     name='keeper',

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -1,0 +1,77 @@
+# coding: utf-8
+"""
+Functional tests for console command syntax
+"""
+
+import os
+import sys
+import pytest
+import unittest.mock
+
+from keeper import main, settings
+
+
+@unittest.mock.patch('os.system')
+def test_edit_command_default(os_system):
+    """
+    check that `keeper edit` command will open all `~/.keeper/*.todo` files
+    """
+    sys.argv = ["keeper", "edit"]
+    homedir = os.path.expanduser('~')
+    settings.EDITOR = 'testeditor'
+    main.main()
+    os_system.assert_called_once_with('testeditor {homedir}/.keeper/*.todo'.format(**locals()))
+
+
+@unittest.mock.patch('os.system')
+def test_edit_command_w_filenames(os_system):
+    """
+    check that `keeper edit <filename>` command will open `~/.keeper/<filename>.todo` file
+    """
+    sys.argv = ["keeper", "edit", "main", "test"]
+    homedir = os.path.expanduser('~')
+    settings.EDITOR = 'testeditor'
+    main.main()
+    os_system.assert_called_once_with('testeditor {homedir}/.keeper/main.todo {homedir}/.keeper/test.todo'\
+                                      .format(**locals()))
+
+
+@unittest.mock.patch('os.system')
+def test_edit_command_w_filenames_w_extensions(os_system):
+    """
+    check that `keeper edit <filename>.todo` (filename with extension)
+    command will open `~/.keeper/<filename>.todo` file
+    """
+    sys.argv = ["keeper", "edit", "main.todo", "test"]
+    homedir = os.path.expanduser('~')
+    settings.EDITOR = 'testeditor'
+    main.main()
+    os_system.assert_called_once_with('testeditor {homedir}/.keeper/main.todo {homedir}/.keeper/test.todo'\
+                                      .format(**locals()))
+
+
+@unittest.mock.patch('os.system')
+def test_edit_command_w_autoeditor(os_system):
+    """
+    check that `keeper edit <filename>` will use first of `settings.POSSIBLE_EDITORS` editors
+    when `settings.EDITOR = 'auto'`
+    """
+    settings.EDITOR = 'auto'
+    sys.argv = ["keeper", "edit", "main"]
+    homedir = os.path.expanduser('~')
+    default_editor = settings.POSSIBLE_EDITORS[0]
+    main.main()
+    os_system.assert_called_once_with('{default_editor} {homedir}/.keeper/main.todo'.format(**locals()))
+
+
+def test_edit_command_no_editor():
+    """
+    check that `keeper edit <filename>` command will raise RuntimeError without available editors
+    """
+    sys.argv = ["keeper", "edit", "main"]
+    settings.EDITOR = 'auto'
+    settings.POSSIBLE_EDITORS = []
+
+    with pytest.raises(RuntimeError):
+        main.main()
+


### PR DESCRIPTION
- app directory and possible editors list are now in settings for better readability - I wasted a couple of minutes the first time to find out why `~/.keeper` was not created automatically and why app used `xed` instead of my default editor, so this was my reaction;
- also made it so `~/.keeper` will be created on first `keeper edit main` command now (like in README);
- changed `Exception` to `RuntimeError` in `find_first_editor` cause `Exception` is too general, imho;
- added py.test tests 'cause py.test is awesome. Just run command `py.test` in the project directory after installing it, it'll find and run its own tests and `unittests` alike;
- added docstring and improved help text for `keeper edit` command, the same will be done for others;
- added some code to allow `keeper edit main` and `keeper edit main.todo` syntax simultaneously



